### PR TITLE
Expose repos as List<Flow<Repo>> from user repos repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 ![Android CI](https://github.com/jshvarts/FlowChannels101/workflows/Android%20CI/badge.svg)
 
-Based on Meetup presentation by https://twitter.com/heyitsmohit found [here](https://speakerdeck.com/heyitsmohit/unit-testing-kotlin-channels-and-flows) with additional code added to demonstrate how Kotlin Flows can be used and unit tested.
+Contains some examples of using `Flow` and `Channels` on Android and unit testing them.
+
+Inspired by Meetup presentation by https://twitter.com/heyitsmohit found [here](https://speakerdeck.com/heyitsmohit/unit-testing-kotlin-channels-and-flows) with additional code added to demonstrate how Kotlin Flows can be used and unit tested.
 

--- a/app/src/main/java/com/example/coroutines/repository/UserReposRepository.kt
+++ b/app/src/main/java/com/example/coroutines/repository/UserReposRepository.kt
@@ -5,8 +5,8 @@ import com.example.coroutines.domain.Repo
 import com.example.coroutines.repository.api.ApiService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import retrofit2.HttpException
 import javax.inject.Inject
@@ -16,8 +16,10 @@ class UserReposRepository @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
 
-    suspend fun getUserRepos(login: String): Flow<Repo> {
-        return apiService.getUserRepos(login).asFlow()
+    suspend fun getUserRepos(login: String): Flow<List<Repo>> {
+        return flow {
+            emit(apiService.getUserRepos(login))
+        }
             .catch { if (it !is HttpException) throw it }
             .flowOn(ioDispatcher)
     }

--- a/app/src/main/java/com/example/coroutines/views/UserReposViewModel.kt
+++ b/app/src/main/java/com/example/coroutines/views/UserReposViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.coroutines.domain.Repo
 import com.example.coroutines.repository.UserReposRepository
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -25,15 +25,16 @@ class UserReposViewModel @Inject constructor(
     fun lookupUserRepos(login: String) {
 
         viewModelScope.launch {
-            _userRepos.value = userReposRepository.getUserRepos(login)
+            userReposRepository.getUserRepos(login)
                 .catch {
                     Timber.e(it.localizedMessage, "error getting user repos")
                     _isError.value = true
                 }
-                .toList()
-                .sortedByDescending { it.stars }
-                .also {
-                    Timber.i("success getting user repos: $it")
+                .collect { data ->
+                    _userRepos.value = data.sortedByDescending { it.stars }
+                        .also {
+                            Timber.i("success getting user repos: $it")
+                        }
                 }
         }
     }

--- a/app/src/test/java/com/example/coroutines/repository/UserReposRepositoryTest.kt
+++ b/app/src/test/java/com/example/coroutines/repository/UserReposRepositoryTest.kt
@@ -6,7 +6,7 @@ import com.example.coroutines.repository.api.ApiService
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeEmpty
@@ -25,7 +25,6 @@ class UserReposRepositoryTest {
         // GIVEN
         val repo1 = Repo(name = "someRepo1", owner = RepoOwner(TEST_USERNAME), stars = 10)
         val repo2 = Repo(name = "someRepo2", owner = RepoOwner(TEST_USERNAME), stars = 55)
-
         val expectedRepoList = listOf(repo1, repo2)
 
         val apiService = mock<ApiService> {
@@ -35,11 +34,12 @@ class UserReposRepositoryTest {
         val repository = UserReposRepository(apiService, testDispatcher)
 
         // WHEN
-        val actualRepoList = repository.getUserRepos(TEST_USERNAME)
-            .toList()
+        val flow = repository.getUserRepos(TEST_USERNAME)
 
         // THEN
-        actualRepoList.shouldBeEqualTo(expectedRepoList)
+        flow.collect { actualRepoList: List<Repo> ->
+            actualRepoList.shouldBeEqualTo(expectedRepoList)
+        }
     }
 
     @Test(expected = IOException::class)
@@ -54,10 +54,12 @@ class UserReposRepositoryTest {
 
             val repository = UserReposRepository(apiService, testDispatcher)
 
-            // WHEN/THEN
-            val actualRepoList = repository.getUserRepos(TEST_USERNAME)
-                .toList()
+            // WHEN
+            val flow = repository.getUserRepos(TEST_USERNAME)
 
-            actualRepoList.shouldBeEmpty()
+            // THEN
+            flow.collect { actualRepoList: List<Repo> ->
+                actualRepoList.shouldBeEmpty()
+            }
         }
 }

--- a/app/src/test/java/com/example/coroutines/views/UserReposViewModelTest.kt
+++ b/app/src/test/java/com/example/coroutines/views/UserReposViewModelTest.kt
@@ -49,8 +49,9 @@ class UserReposViewModelTest {
         // GIVEN
         val repo1 = Repo(name = "someRepo1", owner = RepoOwner(TEST_USERNAME), stars = 55)
         val repo2 = Repo(name = "someRepo2", owner = RepoOwner(TEST_USERNAME), stars = 10)
+        val expectedRepoList = listOf(repo1, repo2)
 
-        val channel = Channel<Repo>()
+        val channel = Channel<List<Repo>>()
         val flow = channel.consumeAsFlow()
 
         doReturn(flow)
@@ -59,22 +60,22 @@ class UserReposViewModelTest {
 
         // WHEN
         launch {
-            channel.send(repo1)
-            channel.send(repo2)
+            channel.send(expectedRepoList)
         }
 
         userReposViewModel.lookupUserRepos(TEST_USERNAME)
 
         // THEN
-        // TODO: even though flow.toList() is a terminal operator, the assertion below does not work
-        // verify(userReposObserver).onChanged(listOf(repo1, repo2))
+        verify(userReposObserver).onChanged(expectedRepoList)
     }
 
     @Test
     fun `should emit error on repos lookup failure`() = rule.dispatcher.runBlockingTest {
         // GIVEN
         val repo1 = Repo(name = "someRepo1", owner = RepoOwner(TEST_USERNAME), stars = 55)
-        val channel = Channel<Repo>()
+        val expectedRepoList = listOf(repo1)
+
+        val channel = Channel<List<Repo>>()
         val flow = channel.consumeAsFlow()
 
         doReturn(flow)
@@ -83,14 +84,14 @@ class UserReposViewModelTest {
 
         // WHEN
         launch {
-            channel.send(repo1)
+            channel.send(expectedRepoList)
             channel.close(IOException())
         }
 
         userReposViewModel.lookupUserRepos(TEST_USERNAME)
 
         // THEN
-        verify(userReposObserver).onChanged(listOf(repo1))
+        verify(userReposObserver).onChanged(expectedRepoList)
         verify(isErrorObserver).onChanged(true)
     }
 }


### PR DESCRIPTION
Loading user repos is a one-shot operation so it makes sense for the `UserReposRepository` to expose a list of user repos as a `Flow<List<Repo>>`